### PR TITLE
Fix agent data quality defaults and column parsing

### DIFF
--- a/automl_platform/agents/universal_ml_agent.py
+++ b/automl_platform/agents/universal_ml_agent.py
@@ -39,7 +39,7 @@ _anthropic_spec = importlib.util.find_spec("anthropic")
 if _anthropic_spec is not None:
     from anthropic import AsyncAnthropic
 else:
-    AsyncAnthronic = None
+    AsyncAnthropic = None
 
 from .intelligent_context_detector import IntelligentContextDetector, MLContext
 from .intelligent_config_generator import IntelligentConfigGenerator, OptimalConfig

--- a/automl_platform/data_quality_agent.py
+++ b/automl_platform/data_quality_agent.py
@@ -12,7 +12,7 @@ import json
 import asyncio
 import os
 from datetime import datetime
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, field, asdict
 import re
 
 logger = logging.getLogger(__name__)
@@ -21,14 +21,15 @@ logger = logging.getLogger(__name__)
 @dataclass
 class DataQualityAssessment:
     """DataRobot-style quality assessment with visual alerts."""
+
     quality_score: float  # 0-100
-    alerts: List[Dict[str, Any]]  # Critical issues requiring attention
-    warnings: List[Dict[str, Any]]  # Non-critical issues
-    recommendations: List[Dict[str, Any]]  # Suggested improvements
-    statistics: Dict[str, Any]  # Statistical summary
-    drift_risk: str  # "low", "medium", "high"
-    target_leakage_risk: bool
-    visualization_data: Dict[str, Any]  # Data for visual quality assessment
+    alerts: List[Dict[str, Any]] = field(default_factory=list)  # Critical issues requiring attention
+    warnings: List[Dict[str, Any]] = field(default_factory=list)  # Non-critical issues
+    recommendations: List[Dict[str, Any]] = field(default_factory=list)  # Suggested improvements
+    statistics: Dict[str, Any] = field(default_factory=dict)  # Statistical summary
+    drift_risk: str = "low"  # "low", "medium", "high"
+    target_leakage_risk: str = "low"  # Align with tests expecting string levels
+    visualization_data: Dict[str, Any] = field(default_factory=dict)  # Data for visual quality assessment
     ml_context: Optional[Dict[str, Any]] = None  # Agent-First ML context
 
 


### PR DESCRIPTION
## Summary
- align `DataQualityAssessment` defaults and typing with test expectations
- refine intelligent cleaner column extraction to avoid false positives
- ensure the universal ML agent defines the Anthropic fallback correctly

## Testing
- pytest tests/test_agents.py -k "extract_column_name" -q
- pytest tests/test_agents.py -k "generate_cleaning_prompts_empty_assessment" -q
- pytest tests/test_agents.py -k "clean_with_agents_error_handling" -q

------
https://chatgpt.com/codex/tasks/task_e_68df276e71d0832494bc88fbfa433211