### PR TITLE
Add rate limiting and credential hardening for cloud connectors

### DIFF
--- a/requirements-optional-doc.md
+++ b/requirements-optional-doc.md
@@ -192,15 +192,15 @@ Computer vision tools:
 ### `[cloud]` - Cloud Providers
 Cloud storage and compute:
 - AWS (boto3, s3fs)
-- Google Cloud (BigQuery, Storage)
+- Google Cloud (BigQuery via `google-cloud-bigquery`, Storage)
 - Azure (Blob Storage, Identity)
-- Snowflake
-- Databricks (databricks-sql-connector for SQL)
+- Snowflake (`snowflake-connector-python`)
+- Databricks SQL (`databricks-sql-connector`)
 
 ### `[connectors]` - Extended Data Connectors
 CRM and database connectors:
 - HubSpot, Salesforce, Pipedrive, Zoho CRM
-- Oracle, MongoDB, Cassandra, Elasticsearch
+- Oracle, MongoDB (`pymongo>=4.6`), Cassandra, Elasticsearch
 - InfluxDB, MySQL
 - Advanced Excel and Google Sheets
 - Databricks (databricks-connect for Spark)


### PR DESCRIPTION
## Summary
- add rate limiting and retry helpers to the connector base class and enable secure BigQuery/Databricks defaults including environment-based credentials
- redact secrets from connection configs, extend connector tests, and document BigQuery/Databricks/Mongo setup guidance plus new throttling controls
- update the optional dependency documentation to highlight the packages required for the new cloud connectors

## Testing
- pytest tests/test_connectors.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e04b0a84e08324adc51ad96db9d13b