### PR TITLE
Harden CRM data source normalization

### DIFF
--- a/automl_platform/ui/utils/__init__.py
+++ b/automl_platform/ui/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for Streamlit UI components."""
+
+from .data_sources import coerce_data_source_identifier, normalize_data_source_label
+
+__all__ = ["coerce_data_source_identifier", "normalize_data_source_label"]

--- a/automl_platform/ui/utils/data_sources.py
+++ b/automl_platform/ui/utils/data_sources.py
@@ -1,0 +1,54 @@
+"""Helpers for normalising and migrating data source identifiers."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Optional
+
+_ZERO_WIDTH_CHARACTERS = {
+    "\u200b",  # zero-width space
+    "\u200c",  # zero-width non-joiner
+    "\u200d",  # zero-width joiner
+    "\ufeff",  # zero-width no-break space / BOM
+}
+
+_NON_BREAKING_SPACES = {"\u202f", "\xa0", "\u2060"}
+
+
+def normalize_data_source_label(label: str) -> str:
+    """Normalise data source labels to make emoji/spacing variants comparable."""
+    sanitized = label
+    for character in _NON_BREAKING_SPACES:
+        sanitized = sanitized.replace(character, " ")
+    for character in _ZERO_WIDTH_CHARACTERS:
+        sanitized = sanitized.replace(character, "")
+    sanitized = sanitized.replace("\ufe0f", "")  # emoji variation selector
+    sanitized = sanitized.strip()
+    sanitized = re.sub(r"^([^\w\s])(?=\w)", r"\1 ", sanitized)
+    sanitized = re.sub(r"\s+", " ", sanitized)
+    return sanitized.casefold()
+
+
+def coerce_data_source_identifier(
+    raw_value: Optional[str],
+    fallback: str,
+    label_by_identifier: Dict[str, str],
+) -> str:
+    """Coerce legacy label-based values to the new identifier format."""
+    if isinstance(raw_value, str):
+        if raw_value in label_by_identifier:
+            return raw_value
+
+        normalized = normalize_data_source_label(raw_value)
+        normalized_compact = normalized.replace(" ", "")
+        for identifier, label in label_by_identifier.items():
+            normalized_label = normalize_data_source_label(label)
+            if normalized_label == normalized:
+                return identifier
+            if normalized_label.replace(" ", "") == normalized_compact:
+                return identifier
+
+    return fallback
+
+
+__all__ = ["normalize_data_source_label", "coerce_data_source_identifier"]

--- a/tests/ui/test_data_sources.py
+++ b/tests/ui/test_data_sources.py
@@ -1,0 +1,29 @@
+"""Tests for UI data source utilities."""
+
+from automl_platform.ui.utils.data_sources import (
+    coerce_data_source_identifier,
+    normalize_data_source_label,
+)
+
+
+def test_normalize_data_source_label_handles_emoji_variants():
+    base = normalize_data_source_label("🤝 CRM")
+    assert normalize_data_source_label("🤝\u202fCRM") == base
+    assert normalize_data_source_label("🤝\u2060CRM") == base
+    assert normalize_data_source_label("🤝CRM") == base
+
+
+def test_coerce_data_source_identifier_maps_legacy_labels():
+    label_by_identifier = {
+        "file": "📁 Fichier local",
+        "crm": "🤝 CRM",
+    }
+    fallback = "file"
+
+    assert coerce_data_source_identifier("crm", fallback, label_by_identifier) == "crm"
+    assert coerce_data_source_identifier("🤝 CRM", fallback, label_by_identifier) == "crm"
+    assert coerce_data_source_identifier("🤝\u202fCRM", fallback, label_by_identifier) == "crm"
+    assert coerce_data_source_identifier("🤝CRM", fallback, label_by_identifier) == "crm"
+    assert coerce_data_source_identifier("🤝\u2060CRM", fallback, label_by_identifier) == "crm"
+    assert coerce_data_source_identifier(None, fallback, label_by_identifier) == "file"
+    assert coerce_data_source_identifier("inconnue", fallback, label_by_identifier) == "file"


### PR DESCRIPTION
## Summary
- share a reusable helper to normalise data-source labels and reuse it in the wizard selector so emoji variants resolve to the CRM identifier
- guard the CRM connector import so the wizard falls back gracefully when optional dependencies are missing
- add unit tests that cover label normalisation and identifier coercion for legacy “🤝 CRM” variants

## Testing
- python -m compileall automl_platform/ui/pages/wizard.py automl_platform/ui/utils/data_sources.py
- pytest tests/ui/test_data_sources.py

------
https://chatgpt.com/codex/tasks/task_e_68e1220ff9a08324827fe0184af9049d