### PR TITLE
Fix distributed training orchestrator usage

### DIFF
--- a/automl_platform/orchestrator.py
+++ b/automl_platform/orchestrator.py
@@ -263,7 +263,7 @@ class AutoMLOrchestrator:
                     }
 
             # Train models in parallel
-            distributed_results = self.distributed_trainer.train_distributed(
+            distributed_results = self.distributed_trainer.train(
                 X,
                 y,
                 distributed_models,


### PR DESCRIPTION
## Summary
- call the distributed training orchestrator's `train` method instead of the nonexistent `train_distributed` wrapper
- update distributed retraining workflows to select the best trained model from orchestrator results and compute metrics locally

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5944f76dc8324954269ced88509b1